### PR TITLE
Support for a wipe tolerance

### DIFF
--- a/lib/jquery.doubletap.js
+++ b/lib/jquery.doubletap.js
@@ -1,4 +1,9 @@
 (function($) {
+  
+  var defaults = {
+    'swipeTolerance': 40
+  };
+  
   var touchStatus = function(target, touch) {
     this.target    = $(target);
     this.touch     = touch;
@@ -6,6 +11,7 @@
     this.startY    = this.currentY = touch.screenY;
     this.eventType = null;
   }
+  touchStatus.options = {};
   touchStatus.latestTap = null;
 
   touchStatus.prototype.move = function(touch) {
@@ -17,15 +23,15 @@
     var offsetX = this.currentX - this.startX;
     var offsetY = this.currentY - this.startY;
     if(offsetX == 0 && offsetY == 0) {
-      this.checkForDoubleTap()
-    } else if(Math.abs(offsetY) > Math.abs(offsetX)) {
+      this.checkForDoubleTap();
+    } else if(Math.abs(offsetY) > touchStatus.options.swipeTolerance && Math.abs(offsetY) > Math.abs(offsetX)) {
       this.eventType = offsetY > 0 ? 'swipedown' : 'swipeup';
       this.target.trigger('swipe', [this])
-    } else {
+    } else if(Math.abs(offsetX) > touchStatus.options.swipeTolerance) {
       this.eventType = offsetX > 0 ? 'swiperight' : 'swipeleft';
       this.target.trigger('swipe', [this])
     }
-    this.target.trigger(this.eventType, [this])
+    if(this.eventType) this.target.trigger(this.eventType, [this])
     this.target.trigger('touch',        [this])
   }
 
@@ -38,7 +44,8 @@
     touchStatus.latestTap = new Date()
   }
 
-  var swipeEvents = function(elements) {
+  var swipeEvents = function(elements, options) {
+    touchStatus.options = $.extend(defaults, options);
     elements.bind('touchstart',  this.touchStart);
     elements.bind('touchmove',   this.touchMove);
     elements.bind('touchcancel', this.touchCancel);
@@ -97,9 +104,13 @@
   //   swipedown
   //   tap
   //   doubletap
-  $.fn.addSwipeEvents = function(callback) {
-    new swipeEvents(this);
-    if(callback) this.bind('touch', callback)
+  $.fn.addSwipeEvents = function(options, callback) { 
+    if (!callback && jQuery.isFunction(options)) {
+      callback = options;
+      options = null;
+    }
+    new swipeEvents(this, options);
+    if(callback) this.bind('touch', callback);
     return this;
   }
 })(jQuery);


### PR DESCRIPTION
Hi there

As discussed, I've got a working version of your code with support added for a swipe tolerance. This is my first time using Git, so my apologies I've not passed this back to you in the correct way.

I'm invoking it like so:

el.addSwipeEvents({swipeTolerance: 50})
  .bind('swipeleft', function(evt, touch) {
    // do stuff
  })
  .bind('swiperight', function(evt, touch) {
    // do stuff
  });

The options object passed to addSwipeEvents is optional. You can substitute it for a callback, or pass the callback as the second parameter.
